### PR TITLE
Update Vague.js

### DIFF
--- a/Vague.js
+++ b/Vague.js
@@ -201,7 +201,7 @@
       var cssFilterValue,
         // variables needed to force the svg filter URL
         loc = window.location,
-        svgUrl = options.forceSVGUrl ? loc.protocol + '//' + loc.host + loc.pathname : '';
+        svgUrl = options.forceSVGUrl ? loc.protocol + '//' + loc.host + loc.pathname + loc.search : '';
 
       // use the css filters if supported
       if (_support.cssfilters) {


### PR DESCRIPTION
Added "loc.search" at the end of var "svgUrl" contents.
Like so the plugin can also be used when the URL contains parameters, otherwise it does not work (at least on Chrome and Firefox).